### PR TITLE
Reduces the Universal Gun Kit's price to 5tc.

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A universal gun kit, that can be combined with any weapon kit to make a functioning RND gun of your own. Uses built in allen keys to self assemble, just combine the kits by hitting them together."
 	reference = "IKEA"
 	item = /obj/item/weaponcrafting/gunkit/universal_gun_kit
-	cost = 8
+	cost = 5
 
 /datum/uplink_item/dangerous/batterer
 	name = "Mind Batterer"


### PR DESCRIPTION
## What Does This PR Do
Reduces the price of the Univseral Gun Kit to 5tc.

## Why It's Good For The Game
The UGK is quite overpriced. The Stechkin is only 4tc for a gun that is likely just as effective as any kit gun.

## Testing
Loaded in, became tator, bought gun kit. It was indeed 5tc.

:cl:
## Changelog
tweak: Lowered UGK price to 5tc
/:cl: