### PR TITLE
Updates ARG rifle description

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -240,7 +240,7 @@
 //ARG Assault Rifle//
 /obj/item/gun/projectile/automatic/ar
 	name = "\improper ARG"
-	desc = "A robust assault rifle used by Nanotrasen fighting forces."
+	desc = "A robust assault rifle used by the forces of the Trans-Solar Federation."
 	icon_state = "arg"
 	item_state = "arg"
 	slot_flags = 0


### PR DESCRIPTION
## What Does This PR Do
Updates the description of the ARG assault rifle to reflect that the TSF and not Nanotrasen use it.

## Why It's Good For The Game
THE LORE, JIM, THE LORE.

## Testing
- Entered game
- Spawned ARG
- Its description has updated
- Shot Beepsky in the face

## Changelog
:cl:
tweak: Updated the ARG rifle's description
/:cl: